### PR TITLE
[FE] getMe 함수 기능 보완 및 클라이언트 측 보안 강화

### DIFF
--- a/client/.gitignore
+++ b/client/.gitignore
@@ -12,6 +12,7 @@ package-lock.json
 dist
 dist-ssr
 *.local
+.env
 
 # Editor directories and files
 .vscode/*

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.5",
         "axios": "^1.4.0",
+        "crypto": "^1.0.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.44.3",
@@ -1861,6 +1862,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/crypto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
+      "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==",
+      "deprecated": "This package is no longer supported. It's now a built-in Node module. If you've depended on crypto, you should switch to the one that's built-in."
     },
     "node_modules/css-color-keywords": {
       "version": "1.0.0",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -26,6 +26,7 @@
       },
       "devDependencies": {
         "@types/crypto-js": "^4.1.1",
+        "@types/node": "^20.3.1",
         "@types/react": "^18.0.37",
         "@types/react-dom": "^18.0.11",
         "@types/styled-components": "^5.1.26",
@@ -1261,6 +1262,12 @@
       "version": "7.0.12",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
       "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "20.3.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.1.tgz",
+      "integrity": "sha512-EhcH/wvidPy1WeML3TtYFGR83UzjxeWRen9V402T8aUGYsCHOmfoisV3ZSg03gAFIbLq8TnWOJ0f4cALtnSEUg==",
       "dev": true
     },
     "node_modules/@types/prop-types": {

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -11,6 +11,7 @@
         "@reduxjs/toolkit": "^1.9.5",
         "axios": "^1.4.0",
         "crypto": "^1.0.1",
+        "crypto-js": "^4.1.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.44.3",
@@ -24,6 +25,7 @@
         "vite-plugin-svgr": "^3.2.0"
       },
       "devDependencies": {
+        "@types/crypto-js": "^4.1.1",
         "@types/react": "^18.0.37",
         "@types/react-dom": "^18.0.11",
         "@types/styled-components": "^5.1.26",
@@ -1234,6 +1236,12 @@
         "url": "https://github.com/sponsors/gregberge"
       }
     },
+    "node_modules/@types/crypto-js": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@types/crypto-js/-/crypto-js-4.1.1.tgz",
+      "integrity": "sha512-BG7fQKZ689HIoc5h+6D2Dgq1fABRa0RbBWKBd9SP/MVRVXROflpm5fhwyATX5duFmbStzyzyycPB8qUYKDH3NA==",
+      "dev": true
+    },
     "node_modules/@types/estree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
@@ -1868,6 +1876,11 @@
       "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
       "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==",
       "deprecated": "This package is no longer supported. It's now a built-in Node module. If you've depended on crypto, you should switch to the one that's built-in."
+    },
+    "node_modules/crypto-js": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
+      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
     },
     "node_modules/css-color-keywords": {
       "version": "1.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -13,6 +13,7 @@
     "@reduxjs/toolkit": "^1.9.5",
     "axios": "^1.4.0",
     "crypto": "^1.0.1",
+    "crypto-js": "^4.1.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.44.3",
@@ -26,6 +27,7 @@
     "vite-plugin-svgr": "^3.2.0"
   },
   "devDependencies": {
+    "@types/crypto-js": "^4.1.1",
     "@types/react": "^18.0.37",
     "@types/react-dom": "^18.0.11",
     "@types/styled-components": "^5.1.26",

--- a/client/package.json
+++ b/client/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@reduxjs/toolkit": "^1.9.5",
     "axios": "^1.4.0",
+    "crypto": "^1.0.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.44.3",

--- a/client/package.json
+++ b/client/package.json
@@ -28,6 +28,7 @@
   },
   "devDependencies": {
     "@types/crypto-js": "^4.1.1",
+    "@types/node": "^20.3.1",
     "@types/react": "^18.0.37",
     "@types/react-dom": "^18.0.11",
     "@types/styled-components": "^5.1.26",

--- a/client/src/common/model/GetMeResponseData.ts
+++ b/client/src/common/model/GetMeResponseData.ts
@@ -1,6 +1,0 @@
-import { IUserInfo } from './UserInfo';
-// 응답에서 data 객체의 구조를 정의
-export interface IGetMeResponseData {
-  user?: IUserInfo | null;
-  accessToken?: string;
-}

--- a/client/src/common/model/UserInfo.ts
+++ b/client/src/common/model/UserInfo.ts
@@ -1,7 +1,25 @@
 // 로그인한 유저의 정보를 담는 인터페이스
 export interface IUserInfo {
-  id: number;
-  name: string;
+  answers: [
+    answerId: number,
+    content: string,
+    createdAt: string,
+    updatedAt: string,
+    answerStatus: any,
+  ][];
+  authorities: ['USER'] | ['USER', 'ADMIN'];
+  createdTime: string;
   email: string;
+  memberId: number;
+  modifiedTime: string;
+  name: string;
+  questions: [
+    questionId: number,
+    title: string,
+    content: string,
+    viewCount: number,
+    createdAt: string,
+    updatedAt: string,
+  ][];
   profileImageUrl: string;
 }

--- a/client/src/common/store/UserInfoStore.tsx
+++ b/client/src/common/store/UserInfoStore.tsx
@@ -2,9 +2,14 @@ import { PayloadAction, configureStore, createSlice } from '@reduxjs/toolkit';
 import { IUserInfo } from '../model/UserInfo';
 
 const initialState: IUserInfo = {
-  id: 0,
+  answers: [],
+  authorities: ['USER'],
+  createdTime: '',
   email: 'abcde123@gmail.com',
   name: '김감자',
+  memberId: 0,
+  modifiedTime: '',
+  questions: [],
   profileImageUrl: 'https://dummyimage.com/100x100/8B4513/ffffff&text=Potato',
 };
 
@@ -14,10 +19,15 @@ export const userInfo = createSlice({
   reducers: {
     createUserInfo: (state, action: PayloadAction<IUserInfo>) => {
       return {
-        id: action.payload.id,
+        answers: action.payload.answers,
+        authorities: action.payload.authorities,
+        createdTime: action.payload.createdTime,
         email: action.payload.email,
         name: action.payload.name,
-        profileImageUrl: action.payload.profileImageUrl,
+        profileImageUrl: state.profileImageUrl,
+        memberId: action.payload.memberId,
+        modifiedTime: action.payload.modifiedTime,
+        questions: action.payload.questions,
       };
     },
   },

--- a/client/src/common/utils/constants.ts
+++ b/client/src/common/utils/constants.ts
@@ -10,8 +10,6 @@ export const GET_ME_URL_EXAMPLE = 'https://localhost:5000/api/v1/users/me';
 
 export const ACCESS_TOKEN: Token = 'accessToken';
 
-export const REFRESH_TOKEN: Token = 'refreshToken';
-
 export const PASSWORD_MIN_LENGTH: number = 8;
 
 export const EMAIL_REGEX: RegExp =

--- a/client/src/common/utils/customHook/useGetMe.tsx
+++ b/client/src/common/utils/customHook/useGetMe.tsx
@@ -4,46 +4,44 @@ import { ACCESS_TOKEN } from '../constants';
 import { useDispatch } from 'react-redux';
 import { createUserInfo } from '../../store/UserInfoStore';
 import { IUserInfo } from '../../model/UserInfo';
-import { IGetMeResponseData } from '../../model/GetMeResponseData';
 import { MembershipUrl } from '../enum';
 
 function useGetMe(): UseQueryResult<IUserInfo | null> {
   const dispatch = useDispatch();
-  // const getMe = async (): Promise<IUserInfo | null> => {
-  const getMe = async () => {
+  const getMe = async (): Promise<IUserInfo | null | undefined> => {
     const accessToken = localStorage.getItem(ACCESS_TOKEN);
     console.log('localstorage에서 받아온 accessToken', accessToken);
     if (!accessToken) {
       return null;
     }
 
+    const headers = {
+      'ngrok-skip-browser-warning': 'true',
+      Authorization: `Bearer ${accessToken}`,
+    };
+
     try {
       const response = await axios.get(MembershipUrl.GetMe, {
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-        },
-        // 이 옵션은 쿠키를 서버와 주고받을 수 있게 해준다. (HTTP only 쿠키로 설정된 refresh token 자동 전송)
-        // withCredentials: true,
+        headers,
+        withCredentials: true,
       });
 
-      // const responseData: IGetMeResponseData = response.data;
-      // const responseData = response.data;
-      console.log('준기님께 계정 정보 전달 후 받아온 데이터', response);
+      const userData: IUserInfo = response.data;
 
-      //   console.log('준기님께 계정 정보 전달 후 받아온 데이터', responseData);
+      dispatch(createUserInfo(userData));
 
-      //   if (!responseData.user) {
-      //     return null;
-      //   }
+      if (userData === null) {
+        return null;
+      }
 
       //   accessToken이 만료되었을 경우 재발급
-      //   if (responseData.accessToken) {
-      //     localStorage.removeItem(ACCESS_TOKEN);
-      //     localStorage.setItem(ACCESS_TOKEN, responseData.accessToken);
-      //   }
-      //   const userInfo: IUserInfo = responseData.user;
-      //   dispatch(createUserInfo(userInfo));
-      //   return userInfo;
+      const newAccessToken = response.headers.authorization.split(' ')[1];
+      if (newAccessToken) {
+        localStorage.removeItem(ACCESS_TOKEN);
+        localStorage.setItem(ACCESS_TOKEN, newAccessToken);
+      }
+
+      return userData;
     } catch (error: any) {
       // refresh token 만료 시 로그아웃 처리
       if (error.response.status === 401) {

--- a/client/src/common/utils/customHook/useGetMe.tsx
+++ b/client/src/common/utils/customHook/useGetMe.tsx
@@ -1,19 +1,35 @@
 import { UseQueryResult, useQuery } from 'react-query';
 import axios from 'axios';
+import CryptoJS from 'crypto-js';
 import { ACCESS_TOKEN } from '../constants';
 import { useDispatch } from 'react-redux';
 import { createUserInfo } from '../../store/UserInfoStore';
 import { IUserInfo } from '../../model/UserInfo';
 import { MembershipUrl } from '../enum';
 
+const secretKey = import.meta.env.VITE_SECRET_KEY;
+
+// Encrypt the access token
+const encryptToken = (tokenToEncrypt: string) => {
+  return CryptoJS.AES.encrypt(tokenToEncrypt, secretKey).toString();
+};
+
+// Decrypt the access token
+const decryptToken = (encryptedToken: string) => {
+  const bytes = CryptoJS.AES.decrypt(encryptedToken, secretKey);
+  return bytes.toString(CryptoJS.enc.Utf8);
+};
+
 function useGetMe(): UseQueryResult<IUserInfo | null> {
   const dispatch = useDispatch();
   const getMe = async (): Promise<IUserInfo | null | undefined> => {
-    const accessToken = localStorage.getItem(ACCESS_TOKEN);
-    console.log('localstorage에서 받아온 accessToken', accessToken);
-    if (!accessToken) {
+    const encryptedAccessToken = localStorage.getItem(ACCESS_TOKEN);
+
+    if (!encryptedAccessToken) {
       return null;
     }
+
+    const accessToken = decryptToken(encryptedAccessToken);
 
     const headers = {
       'ngrok-skip-browser-warning': 'true',
@@ -28,23 +44,23 @@ function useGetMe(): UseQueryResult<IUserInfo | null> {
 
       const userData: IUserInfo = response.data;
 
-      dispatch(createUserInfo(userData));
-
-      if (userData === null) {
+      if (!userData || !response?.headers.authorization) {
         return null;
       }
+
+      dispatch(createUserInfo(userData));
 
       //   accessToken이 만료되었을 경우 재발급
       const newAccessToken = response.headers.authorization.split(' ')[1];
       if (newAccessToken) {
         localStorage.removeItem(ACCESS_TOKEN);
-        localStorage.setItem(ACCESS_TOKEN, newAccessToken);
+        localStorage.setItem(ACCESS_TOKEN, encryptToken(newAccessToken));
       }
 
       return userData;
     } catch (error: any) {
       // refresh token 만료 시 로그아웃 처리
-      if (error.response.status === 401) {
+      if (error?.response?.status === 401) {
         localStorage.removeItem(ACCESS_TOKEN);
       } else {
         console.error(error);

--- a/client/src/common/utils/enum.ts
+++ b/client/src/common/utils/enum.ts
@@ -1,7 +1,8 @@
-const BASE_URL = 'https://0313-220-127-158-194.ngrok-free.app';
+const BASE_URL = 'https://66d2-220-127-158-194.ngrok-free.app';
 
-export const enum MembershipUrl {
+export enum MembershipUrl {
   SignUp = `${BASE_URL}/members`,
   Login = `${BASE_URL}/auth/login`,
   GetMe = `${BASE_URL}/members/me`,
+  Withdrawal = `${BASE_URL}/members/delete`,
 }

--- a/client/src/pages/Login/components/LoginForm.tsx
+++ b/client/src/pages/Login/components/LoginForm.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useMutation } from 'react-query';
 import axios from 'axios';
+import CryptoJS from 'crypto-js';
 import useGetMe from '../../../common/utils/customHook/useGetMe';
 import UserInfoLabel from '../../../common/components/UserInfoLabel';
 import {
@@ -30,6 +31,13 @@ import { MembershipUrl } from '../../../common/utils/enum';
 import { useNavigate } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { RootState } from '../../../common/store/RootStore';
+
+const secretKey = import.meta.env.VITE_SECRET_KEY;
+
+// Encrypt the access token
+const encryptToken = (token: string) => {
+  return CryptoJS.AES.encrypt(token, secretKey).toString();
+};
 
 const postData = async (data: IUserInfoLogin) => {
   const response = await axios.post(MembershipUrl.Login, data);
@@ -60,7 +68,7 @@ function LoginForm() {
       );
 
       localStorage.removeItem(ACCESS_TOKEN);
-      localStorage.setItem(ACCESS_TOKEN, accessToken);
+      localStorage.setItem(ACCESS_TOKEN, encryptToken(accessToken));
 
       await refetchGetMe();
 
@@ -92,6 +100,7 @@ function LoginForm() {
 
   const memberId = useSelector((state: RootState) => state.userInfo.memberId);
   const handleWithdrawal = async () => {
+    localStorage.removeItem(ACCESS_TOKEN);
     const response = await axios.delete(
       MembershipUrl.Withdrawal + `/${memberId}`,
     );

--- a/client/src/pages/Login/components/LoginForm.tsx
+++ b/client/src/pages/Login/components/LoginForm.tsx
@@ -16,7 +16,6 @@ import {
   email,
   password,
   ACCESS_TOKEN,
-  REFRESH_TOKEN,
   PASSWORD_MIN_LENGTH,
   EMAIL_REGEX,
   PASSWORD_REGEX,
@@ -28,10 +27,13 @@ import {
 } from '../../../common/utils/constants';
 import ConfirmButton from '../../SignUp/components/ConfirmButton';
 import { MembershipUrl } from '../../../common/utils/enum';
+import { useNavigate } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+import { RootState } from '../../../common/store/RootStore';
 
 const postData = async (data: IUserInfoLogin) => {
   const response = await axios.post(MembershipUrl.Login, data);
-  console.log('준기님께 계정 정보 전달 후 받아온 데이터', response.headers);
+  console.log('2 준기님께 계정 정보 전달 후 받아온 데이터', response.headers);
   return response.headers;
 };
 
@@ -47,20 +49,25 @@ function LoginForm() {
   const { refetch: refetchGetMe } = useGetMe();
 
   const mutation = useMutation(postData, {
-    onSuccess: async (data) => {
-      if (!data) {
+    onSuccess: async (header) => {
+      if (!header) {
         return;
       }
-      const accessToken = data.authorization.split(' ')[1];
+      const accessToken: string = header.authorization.split(' ')[1];
+      console.log(
+        '3 준기님께 계정 정보 전달 후 받아온 accessToken',
+        accessToken,
+      );
 
       localStorage.removeItem(ACCESS_TOKEN);
       localStorage.setItem(ACCESS_TOKEN, accessToken);
 
-      const { data: userData } = await refetchGetMe();
-      console.log(userData);
+      await refetchGetMe();
+
+      navigate('/');
     },
     onError: (error) => {
-      console.error(error);
+      console.log(error);
       // TODO: 에러 처리
       // 이메일 형식이 잘못됨 (400) -> The email is not a valid email address.
       // 비밀번호가 잘못됨 (401) -> The email or password is incorrect.
@@ -70,45 +77,61 @@ function LoginForm() {
   });
 
   const onSubmit = async (userData: IUserInfoLogin) => {
-    console.log(userData);
+    console.log('1 유저데이터', userData);
     setIsClicked(true);
 
     await mutation.mutateAsync(userData);
   };
 
+  const navigate = useNavigate();
+
+  const handleLogout = () => {
+    localStorage.removeItem(ACCESS_TOKEN);
+    navigate('/');
+  };
+
+  const memberId = useSelector((state: RootState) => state.userInfo.memberId);
+  const handleWithdrawal = async () => {
+    const response = await axios.delete(
+      MembershipUrl.Withdrawal + `/${memberId}`,
+    );
+    console.log(response);
+  };
+
   return (
-    <StyledForm onSubmit={handleSubmit(onSubmit)}>
-      <UserInfoWrapper>
-        <UserInfoLabel label={'Email'} />
-        <StyledInput
-          {...register(email, {
-            required: WARNING_MESSAGE_EMAIL_EMPTY,
-            pattern: {
-              value: EMAIL_REGEX,
-              message: `${watch(email)} is not a valid email address`,
-            },
-          })}
-        />
-        {errors?.email?.message === WARNING_MESSAGE_EMAIL_EMPTY ||
-        (isClicked && typeof errors?.email?.message === 'string') ? (
-          <ErrorMsg>{errors.email.message}</ErrorMsg>
-        ) : null}
-      </UserInfoWrapper>
-      <UserInfoWrapper>
-        <UserInfoLabel label={'Password'} />
-        <StyledInput
-          type="password"
-          {...register(password, {
-            required: WARNING_MESSAGE_PASSWORD_EMPTY,
-            minLength: {
-              value: PASSWORD_MIN_LENGTH,
-              message: `Must contain at least ${
-                PASSWORD_MIN_LENGTH - (watch(password)?.length || 0)
-              } more characters.`,
-            },
-            pattern: {
-              value: PASSWORD_REGEX,
-              message: `${WARNING_MESSAGE_PASSWORD_WEAK}: 
+    <>
+      <StyledForm onSubmit={handleSubmit(onSubmit)}>
+        <UserInfoWrapper>
+          <UserInfoLabel label={'Email'} />
+          <StyledInput
+            {...register(email, {
+              required: WARNING_MESSAGE_EMAIL_EMPTY,
+              pattern: {
+                value: EMAIL_REGEX,
+                message: `${watch(email)} is not a valid email address`,
+              },
+            })}
+          />
+          {errors?.email?.message === WARNING_MESSAGE_EMAIL_EMPTY ||
+          (isClicked && typeof errors?.email?.message === 'string') ? (
+            <ErrorMsg>{errors.email.message}</ErrorMsg>
+          ) : null}
+        </UserInfoWrapper>
+        <UserInfoWrapper>
+          <UserInfoLabel label={'Password'} />
+          <StyledInput
+            type="password"
+            {...register(password, {
+              required: WARNING_MESSAGE_PASSWORD_EMPTY,
+              minLength: {
+                value: PASSWORD_MIN_LENGTH,
+                message: `Must contain at least ${
+                  PASSWORD_MIN_LENGTH - (watch(password)?.length || 0)
+                } more characters.`,
+              },
+              pattern: {
+                value: PASSWORD_REGEX,
+                message: `${WARNING_MESSAGE_PASSWORD_WEAK}: 
                   ${
                     watch(password) &&
                     PASSWORD_REGEX_NO_LETTERS.test(watch(password))
@@ -121,20 +144,27 @@ function LoginForm() {
                       ? 'numbers'
                       : ''
                   }`,
-            },
-          })}
+              },
+            })}
+          />
+          {errors?.password?.message === WARNING_MESSAGE_PASSWORD_EMPTY ||
+          (isClicked && typeof errors?.password?.message === 'string') ? (
+            <ErrorMsg>{errors.password.message}</ErrorMsg>
+          ) : null}
+        </UserInfoWrapper>
+        <ConfirmButton
+          type="submit"
+          setIsClicked={setIsClicked}
+          buttontext={'Log in'}
         />
-        {errors?.password?.message === WARNING_MESSAGE_PASSWORD_EMPTY ||
-        (isClicked && typeof errors?.password?.message === 'string') ? (
-          <ErrorMsg>{errors.password.message}</ErrorMsg>
-        ) : null}
-      </UserInfoWrapper>
-      <ConfirmButton
-        type="submit"
-        setIsClicked={setIsClicked}
-        buttontext={'Log in'}
-      />
-    </StyledForm>
+        <button onClick={handleLogout}>log out</button>
+      </StyledForm>
+      <section>
+        <h1>회원 탈퇴</h1>
+
+        <button onClick={handleWithdrawal}>withdraw</button>
+      </section>
+    </>
   );
 }
 export default LoginForm;

--- a/client/src/pages/Login/views/Login.tsx
+++ b/client/src/pages/Login/views/Login.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import LoginForm from '../components/LoginForm';
+import LoginForm from './LoginForm';
 import { LoginPageContainer } from '../style';
 
 function Login() {

--- a/client/src/pages/Login/views/LoginForm.tsx
+++ b/client/src/pages/Login/views/LoginForm.tsx
@@ -100,10 +100,8 @@ function LoginForm() {
   const memberId = useSelector((state: RootState) => state.userInfo.memberId);
   const handleWithdrawal = async () => {
     localStorage.removeItem(ACCESS_TOKEN);
-    const response = await axios.delete(
-      MembershipUrl.Withdrawal + `/${memberId}`,
-    );
-    console.log(response);
+    await axios.delete(MembershipUrl.Withdrawal + `/${memberId}`);
+    navigate('/');
   };
 
   return (

--- a/client/src/pages/Login/views/LoginForm.tsx
+++ b/client/src/pages/Login/views/LoginForm.tsx
@@ -160,16 +160,12 @@ function LoginForm() {
             <ErrorMsg>{errors.password.message}</ErrorMsg>
           ) : null}
         </UserInfoWrapper>
-        <ConfirmButton
-          type="submit"
-          setIsClicked={setIsClicked}
-          buttontext={'Log in'}
-        />
+        <ConfirmButton setIsClicked={setIsClicked} buttontext={'Log in'} />
+        <h1>로그아웃</h1>
         <button onClick={handleLogout}>log out</button>
       </StyledForm>
       <section>
         <h1>회원 탈퇴</h1>
-
         <button onClick={handleWithdrawal}>withdraw</button>
       </section>
     </>

--- a/client/src/pages/Login/views/LoginForm.tsx
+++ b/client/src/pages/Login/views/LoginForm.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useMutation } from 'react-query';

--- a/client/src/pages/MyPage/views/MyPage.tsx
+++ b/client/src/pages/MyPage/views/MyPage.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 function MyPage() {
   return <div>mypage</div>;
 }

--- a/client/src/pages/SignUp/components/ConfirmButton.tsx
+++ b/client/src/pages/SignUp/components/ConfirmButton.tsx
@@ -1,9 +1,9 @@
 import { BlueButtonMembership } from '../style';
 import { ConfirmButtonProps } from '../type';
 
-function ConfirmButton({ type, setIsClicked, buttontext }: ConfirmButtonProps) {
+function ConfirmButton({ setIsClicked, buttontext }: ConfirmButtonProps) {
   return (
-    <BlueButtonMembership onClick={() => setIsClicked(true)}>
+    <BlueButtonMembership type="submit" onClick={() => setIsClicked(true)}>
       {buttontext}
     </BlueButtonMembership>
   );

--- a/client/src/pages/SignUp/style.ts
+++ b/client/src/pages/SignUp/style.ts
@@ -70,7 +70,7 @@ export const TextWrapper3 = styled(TextWrapper)`
   width: 360px;
 `;
 
-export const RobotBoxContainer = styled.form`
+export const RobotBoxContainer = styled.section`
   display: flex;
   justify-content: center;
   align-items: center;

--- a/client/src/pages/SignUp/type.ts
+++ b/client/src/pages/SignUp/type.ts
@@ -1,5 +1,4 @@
 export type ConfirmButtonProps = {
-  type: string;
   setIsClicked: (isClicked: boolean) => void;
   buttontext: string;
 };

--- a/client/src/pages/SignUp/views/SignUpForm.tsx
+++ b/client/src/pages/SignUp/views/SignUpForm.tsx
@@ -27,7 +27,6 @@ import {
   email,
   password,
   ACCESS_TOKEN,
-  REFRESH_TOKEN,
   PASSWORD_MIN_LENGTH,
   EMAIL_REGEX,
   PASSWORD_REGEX,
@@ -43,9 +42,13 @@ import { MembershipUrl } from '../../../common/utils/enum';
 import { ErrorMsg } from '../../../common/style';
 
 const postData = async (data: IUserInfoSignUp) => {
+  console.log('1. 준기님께 보내는 유저 정보', data);
   const response = await axios.post(MembershipUrl.SignUp, data);
+  console.log('2. 준기님께 계정 정보 전달 후 받아온 데이터', response);
 
-  return response.data;
+  console.log('3. 준기님께 계정 정보 전달 후 받아온 헤더', response.headers);
+
+  return response.headers;
 };
 
 function SignUpForm() {
@@ -57,21 +60,26 @@ function SignUpForm() {
     formState: { errors },
   } = useForm<IUserInfoSignUp>();
 
-  const { refetch: refetchGetMe } = useGetMe();
+  // const { refetch: refetchGetMe } = useGetMe();
 
   const mutation = useMutation(postData, {
-    onSuccess: async (data) => {
-      console.log('준기님께 계정 정보 전달 후 받아온 데이터', data);
-      if (!data) {
-        return;
-      }
-      const { accessToken, refreshToken } = data.tokens;
+    onSuccess: async (headers) => {
+      console.log('3. 준기님께 계정 정보 전달 후 받아온 데이터', headers);
+      return null;
+      // if (!headers) {
+      //   return;
+      // }
+      // const accessToken = headers.Authorization;
 
-      localStorage.setItem(ACCESS_TOKEN, accessToken);
-      localStorage.setItem(REFRESH_TOKEN, refreshToken);
+      // console.log(
+      //   '4. 준기님께 계정 정보 전달 후 받아온 accessToken',
+      //   accessToken,
+      // );
 
-      const { data: userData } = await refetchGetMe();
-      console.log(userData);
+      // localStorage.setItem(ACCESS_TOKEN, accessToken);
+
+      // const { data: userData } = await refetchGetMe();
+      // console.log(userData);
     },
     onError: (error) => {
       console.error(error);
@@ -83,7 +91,7 @@ function SignUpForm() {
   });
 
   const onSubmit = async (userData: IUserInfoSignUp) => {
-    console.log('준기님께 보내는 유저 정보', userData);
+    console.log('1. 준기님께 보내는 유저 정보', userData);
     setIsClicked(true);
     await mutation.mutateAsync(userData);
   };
@@ -148,14 +156,14 @@ function SignUpForm() {
       <TextWrapper>
         <Text>{PASSWORD_RULE_MESSAGE}</Text>
       </TextWrapper>
-      <RobotBoxContainer>
-        <RobotBox>
-          <TextWrapper4>
-            <StyledInput type="checkbox" />
-            <Text3>I'm not a robot</Text3>
-          </TextWrapper4>
-        </RobotBox>
-      </RobotBoxContainer>
+      {/* <RobotBoxContainer> */}
+      <RobotBox>
+        <TextWrapper4>
+          <StyledInput type="checkbox" />
+          <Text3>I'm not a robot</Text3>
+        </TextWrapper4>
+      </RobotBox>
+      {/* </RobotBoxContainer> */}
       <TextWrapper2>
         <CheckBoxWrapper>
           <CheckBox type="checkbox" />

--- a/client/src/pages/SignUp/views/SignUpForm.tsx
+++ b/client/src/pages/SignUp/views/SignUpForm.tsx
@@ -156,14 +156,14 @@ function SignUpForm() {
       <TextWrapper>
         <Text>{PASSWORD_RULE_MESSAGE}</Text>
       </TextWrapper>
-      {/* <RobotBoxContainer> */}
-      <RobotBox>
-        <TextWrapper4>
-          <StyledInput type="checkbox" />
-          <Text3>I'm not a robot</Text3>
-        </TextWrapper4>
-      </RobotBox>
-      {/* </RobotBoxContainer> */}
+      <RobotBoxContainer>
+        <RobotBox>
+          <TextWrapper4>
+            <StyledInput type="checkbox" />
+            <Text3>I'm not a robot</Text3>
+          </TextWrapper4>
+        </RobotBox>
+      </RobotBoxContainer>
       <TextWrapper2>
         <CheckBoxWrapper>
           <CheckBox type="checkbox" />

--- a/client/src/pages/SignUp/views/SignUpForm.tsx
+++ b/client/src/pages/SignUp/views/SignUpForm.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useMutation } from 'react-query';
 import axios from 'axios';
-import useGetMe from '../../../common/utils/customHook/useGetMe';
+// import useGetMe from '../../../common/utils/customHook/useGetMe';
 import UserInfoLabel from '../../../common/components/UserInfoLabel';
 import {
   StyledInput,
@@ -26,7 +26,7 @@ import {
   name,
   email,
   password,
-  ACCESS_TOKEN,
+  // ACCESS_TOKEN,
   PASSWORD_MIN_LENGTH,
   EMAIL_REGEX,
   PASSWORD_REGEX,
@@ -173,11 +173,7 @@ function SignUpForm() {
           invitations, company announcements, and digests.
         </Text2>
       </TextWrapper2>
-      <ConfirmButton
-        type="submit"
-        setIsClicked={setIsClicked}
-        buttontext={'Sign Up'}
-      />
+      <ConfirmButton setIsClicked={setIsClicked} buttontext={'Sign Up'} />
       <TextWrapper>
         <Text>
           By clicking “Sign up”, you agree to our terms of service and


### PR DESCRIPTION
getMe 함수 기존 기능 보완 및 새로운 기능 구현
    - 유저 정보 get 요청 시 header에 'ngrok-skip-browser-warning': 'true' 추가하여 CORS 에러 해결
    - access token을 local storage에 저장 시 클라이언트 측에서 자체 암호화하는 기능 추가
    - 로그인된 유저 정보를 유저 정보 store에 추가
    - API 명세서 상의 유저 정보 데이터 반영하여 userInfo store의 initial state, interface ,action 변경
 
로그아웃, 회원 탈퇴 기능 구현
    - home 컴포넌트로 navigate 되도록 구현